### PR TITLE
[Warlock] Affliction APL: Shuffle priorities of DoTs & Shadow Embrace

### DIFF
--- a/engine/class_modules/apl/warlock/affliction.simc
+++ b/engine/class_modules/apl/warlock/affliction.simc
@@ -21,8 +21,8 @@ actions+=/call_action_list,name=items
 actions+=/soul_swap,if=dot.unstable_affliction.remains<5
 actions+=/unstable_affliction,if=remains<5
 actions+=/agony,if=remains<5
-actions+=/siphon_life,if=remains<5
 actions+=/corruption,if=remains<5
+actions+=/siphon_life,if=remains<5
 actions+=/haunt
 actions+=/drain_soul,if=talent.shadow_embrace&(debuff.shadow_embrace.stack<3|debuff.shadow_embrace.remains<3)
 actions+=/shadow_bolt,if=talent.shadow_embrace&(debuff.shadow_embrace.stack<3|debuff.shadow_embrace.remains<3)
@@ -40,6 +40,8 @@ actions+=/malefic_rapture,if=talent.tormented_crescendo&talent.nightfall&buff.ni
 actions+=/drain_life,if=buff.inevitable_demise.stack>48|buff.inevitable_demise.stack>20&time_to_die<4
 actions+=/drain_soul,if=buff.nightfall.up
 actions+=/shadow_bolt,if=buff.nightfall.up
+actions+=/agony,if=refreshable
+actions+=/corruption,if=refreshable
 actions+=/soul_tap
 actions+=/drain_soul,interrupt=1
 actions+=/shadow_bolt

--- a/engine/class_modules/apl/warlock/affliction.simc
+++ b/engine/class_modules/apl/warlock/affliction.simc
@@ -18,13 +18,14 @@ actions+=/call_action_list,name=cleave,if=active_enemies!=1&active_enemies<4|var
 actions+=/call_action_list,name=aoe,if=active_enemies>3
 actions+=/call_action_list,name=ogcd
 actions+=/call_action_list,name=items
-actions+=/haunt
 actions+=/soul_swap,if=dot.unstable_affliction.remains<5
 actions+=/unstable_affliction,if=remains<5
 actions+=/agony,if=remains<5
 actions+=/siphon_life,if=remains<5
 actions+=/corruption,if=remains<5
-actions+=/soul_tap
+actions+=/haunt
+actions+=/drain_soul,if=talent.shadow_embrace&(debuff.shadow_embrace.stack<3|debuff.shadow_embrace.remains<3)
+actions+=/shadow_bolt,if=talent.shadow_embrace&(debuff.shadow_embrace.stack<3|debuff.shadow_embrace.remains<3)
 actions+=/phantom_singularity,if=!talent.soul_rot|cooldown.soul_rot.remains<=execute_time|!talent.summon_darkglare
 actions+=/vile_taint
 actions+=/soul_rot,if=variable.ps_up&variable.vt_up|!talent.summon_darkglare
@@ -36,11 +37,10 @@ actions+=/malefic_rapture,if=buff.tormented_crescendo.up&!debuff.dread_touch.up
 actions+=/malefic_rapture,if=talent.tormented_crescendo&buff.tormented_crescendo.stack=2
 actions+=/malefic_rapture,if=variable.cd_dots_up
 actions+=/malefic_rapture,if=talent.tormented_crescendo&talent.nightfall&buff.nightfall.up&buff.tormented_crescendo.up
-actions+=/drain_soul,if=buff.nightfall.react|talent.shadow_embrace&(debuff.shadow_embrace.stack<3|debuff.shadow_embrace.remains<2)
-actions+=/shadow_bolt,if=buff.nightfall.react|talent.shadow_embrace&(debuff.shadow_embrace.stack<3|debuff.shadow_embrace.remains<2)
 actions+=/drain_life,if=buff.inevitable_demise.stack>48|buff.inevitable_demise.stack>20&time_to_die<4
-actions+=/agony,if=refreshable
-actions+=/corruption,if=refreshable
+actions+=/drain_soul,if=buff.nightfall.up
+actions+=/shadow_bolt,if=buff.nightfall.up
+actions+=/soul_tap
 actions+=/drain_soul,interrupt=1
 actions+=/shadow_bolt
 


### PR DESCRIPTION
Requires https://github.com/Denis101/simc/pull/3

New DoT order of priority:
* Soul Swap (if available)
* Unstable Affliction
* Agony
* Corruption
* Siphon Life
* Haunt (note; this is pre-cast on pull so should already be up on opener)

Increased priority of Drain Soul/Shadow Bolt to build 3 stacks of Shadow Embrace **before** activating CDs.

Drain Soul/Shadow Bolt on Nightfall procs below ID Drain Life.

Soul Tap deprioritised, should only be used in filler scenarios really (and is getting removed in a few weeks anyway).

Before: https://www.raidbots.com/simbot/report/9uZ1D5iQ4th4ayXofnXNc6
After: https://www.raidbots.com/simbot/report/uKS19N7hHYa3TpFNWFRot6